### PR TITLE
Add basic credentials

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -29,10 +29,12 @@ except:
 
 # Credentials for database
 try:
-  from newebe.local_settings import USERNAME, PASSWORD
+  from newebe.local_settings import USERNAME, PASSWORD, COUCHDB_SERVER_USERNAME, COUCHDB_SERVER_PASSWORD
 except:
   USERNAME = "newebe"
   PASSWORD = "newebe"
+  COUCHDB_SERVER_USERNAME = "admin"
+  COUCHDB_SERVER_PASSWORD = "admin"
 
 
 # Couchdb configuration

--- a/settings.py
+++ b/settings.py
@@ -27,10 +27,16 @@ except:
     PRIVATE_KEY = os.path.join("./", "server.key")
     CERTIFICATE = os.path.join("./", "server.crt")
 
+# Credentials for database
+try:
+  from newebe.local_settings import USERNAME, PASSWORD
+except:
+  USERNAME = "newebe"
+  PASSWORD = "newebe"
 
 
 # Couchdb configuration
-COUCHDB_DB_URI =  'http://127.0.0.1:5984/%s' % COUCHDB_DB_NAME
+COUCHDB_DB_URI =  'http://%s:%s@127.0.0.1:5984/%s' % (USERNAME, PASSWORD, COUCHDB_DB_NAME)
 COUCHDB_DATABASES = (
     ('newebe.news', COUCHDB_DB_URI),
     ('newebe.core', COUCHDB_DB_URI),


### PR DESCRIPTION
Add basic credentials with a username and a password to access the newebe database.

You will have to add this user to your couchdb server to do this :
- add the correct user (or "newebe") to the _users database :

```
{
  "_id": "org.couchdb .user:newebe",
  "type": "user",
  "name": "newebe",
  "password": "newebe"
}
```
- add this user to the security settings of the `newebe` database (using Futon, for instance)
